### PR TITLE
TED ID 検索機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    mini_portile (0.6.2)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  nokogiri
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ TEDビデオをダウンロードして、英語・日本語の字幕をつけ�
 ## 準備
 
 ```
-git clone git@github.com:maeda1150/download_translated_TED.git
-cd download_translated_TED
+$ git clone git@github.com:maeda1150/download_translated_TED.git
+$ cd download_translated_TED
+$ bundle install
 ```
 
 ### 必要なソフト
@@ -22,30 +23,48 @@ cd download_translated_TED
 
 ##### mplayer
 ```
-which mplayer
+$ which mplayer
 ```
 入っていない時は `brew install mplayer` または http://mplayerx.org よりダウンロード
 
 ##### ruby
 ```
-which ruby
+$ which ruby
 ```
 入っていない時は`brew install ruby`
 
 ##### python
 ```
-which python
+$ which python
 ```
 入っていない時は`brew install python`
 
 ## 使い方
 
-#### [ted](https://www.ted.com/)のwebsiteでダウンロードしたい ted ID を確認する
+#### TED ID を調べる
+1. [ted](https://www.ted.com/)のwebsiteで確認する
 
 ![](https://raw.githubusercontent.com/maeda1150/download_translated_TED/master/images/ted.jpg)
 
 ![](https://raw.githubusercontent.com/maeda1150/download_translated_TED/master/images/get_id.jpg)
 
+2. コマンドラインから確認する
+```
+$ scripts/search.rb
+id. duration title
+ 1. 13:03  日常の音に隠された思いがけない美とは
+ 2. 21:47  なぜ気候変動が人権を脅かすのか
+ 3. 15:57  斬首動画が何百万回も再生されてしまう理由
+ 4. 17:03  学校を閉鎖しようとするタリバンを、私がどう阻止したか
+ 5. 15:16  世間で語られる貧困の嘘
+ 6. 18:00  恐怖が動かすアメリカの政治
+…
+
+[USAGE] 'next': show next videos, '[id]': download translated video
+4
+
+TED ID: 2337
+```
 
 #### スクリプト実行
 ted IDを指定して実行

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ TEDビデオをダウンロードして、英語・日本語の字幕をつけ�
 
 ![](https://raw.githubusercontent.com/maeda1150/download_translated_TED/master/images/screen_shot.png)
 
-※mac環境でのみ確認済
+※OS Xでのみ確認済
 
 ## 準備
 
@@ -25,30 +25,29 @@ $ bundle install
 ```
 $ which mplayer
 ```
-入っていない時は `brew install mplayer` または http://mplayerx.org よりダウンロード
+入っていない時は `$ brew install mplayer` または http://mplayerx.org よりダウンロード
 
 ##### ruby
 ```
 $ which ruby
 ```
-入っていない時は`brew install ruby`
+入っていない時は`$ brew install ruby`
 
 ##### python
 ```
 $ which python
 ```
-入っていない時は`brew install python`
+入っていない時は`$ brew install python`
 
 ## 使い方
 
 #### TED ID を調べる
-1. [ted](https://www.ted.com/)のwebsiteで確認する
-
+1. [TED](https://www.ted.com/)のWebSiteで確認する
 ![](https://raw.githubusercontent.com/maeda1150/download_translated_TED/master/images/ted.jpg)
-
 ![](https://raw.githubusercontent.com/maeda1150/download_translated_TED/master/images/get_id.jpg)
 
-2. コマンドラインから確認する
+1. コマンドラインから確認する
+
 ```
 $ scripts/search.rb
 id. duration title
@@ -60,16 +59,16 @@ id. duration title
  6. 18:00  恐怖が動かすアメリカの政治
 …
 
-[USAGE] 'next': show next videos, '[id]': download translated video
+[USAGE] 'next': show next videos, '[id]': show TED ID, 'exit': exit
 4
 
 TED ID: 2337
 ```
 
 #### スクリプト実行
-ted IDを指定して実行
+TED IDを指定して実行
 ```
-bash ted [ted ID]
+bash ted [TED ID]
 ```
 
 `videos`以下に保存されます。
@@ -77,7 +76,7 @@ bash ted [ted ID]
 #### おすすめの再生方法
 **mplayer**で再生する
 ```
-mplayer AlGore_2006-480p.mp4
+$ mplayer AlGore_2006-480p.mp4
 ```
 
 **mplayer コマンド**

--- a/scripts/search.rb
+++ b/scripts/search.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+
+require 'open-uri'
+require 'nokogiri'
+
+PREFIX = 'https://www.ted.com'
+LIST_URL = '/talks?language=ja&page='
+PER_PAGE = 36
+@page = 1
+@store = {}
+@video_id = 0
+
+def fetch_videos
+  html = Nokogiri::HTML(open(PREFIX + LIST_URL + @page.to_s))
+  result = html.xpath('//*[@id="browse-results"]/div/div')
+  puts 'id. duration title'
+  result.each_with_index do |video, i|
+    break if i == PER_PAGE
+    video_url = video.xpath('.//*/h4')[1].xpath('./a').first['href']
+    title = video.xpath('.//*/h4')[1].xpath('./a').first.text.delete("\n")
+    duration = video.xpath('.//*/span[@class="thumb__duration"]').text
+    @store[i + 1] = video_url
+    puts "#{format('%2d', i + 1)}. #{duration}  #{title}"
+  end
+end
+
+def video_id(video_url)
+  html = Nokogiri::HTML(open(PREFIX + video_url))
+  html.xpath('/html/head/meta').each do |meta|
+    next unless meta['name'] == 'twitter:app:url:ipad'
+    return meta['content'].match(/talkID=([0-9]+)&source/)[1].to_i
+  end
+end
+
+def show_usage
+  puts "\n"
+  puts "[USAGE] 'next': show next videos, '[id]': download translated video"
+end
+
+# main
+fetch_videos
+loop do
+  show_usage
+  cmd = gets.chomp
+  if cmd == 'next'
+    @page += 1
+    puts "\n"
+    fetch_videos
+  elsif 0 < cmd.to_i && cmd.to_i < PER_PAGE
+    puts "\n"
+    puts "TED ID: #{video_id(@store[cmd.to_i])}"
+    break
+  end
+end

--- a/scripts/search.rb
+++ b/scripts/search.rb
@@ -8,7 +8,6 @@ LIST_URL = '/talks?language=ja&page='
 PER_PAGE = 36
 @page = 1
 @store = {}
-@video_id = 0
 
 def fetch_videos
   html = Nokogiri::HTML(open(PREFIX + LIST_URL + @page.to_s))
@@ -24,7 +23,7 @@ def fetch_videos
   end
 end
 
-def video_id(video_url)
+def ted_id(video_url)
   html = Nokogiri::HTML(open(PREFIX + video_url))
   html.xpath('/html/head/meta').each do |meta|
     next unless meta['name'] == 'twitter:app:url:ipad'
@@ -34,7 +33,7 @@ end
 
 def show_usage
   puts "\n"
-  puts "[USAGE] 'next': show next videos, '[id]': download translated video"
+  puts "[USAGE] 'next': show next videos, '[id]': show TED ID, 'exit': exit"
 end
 
 # main
@@ -46,9 +45,11 @@ loop do
     @page += 1
     puts "\n"
     fetch_videos
-  elsif 0 < cmd.to_i && cmd.to_i < PER_PAGE
+  elsif cmd == 'exit'
+    break
+  elsif 0 < cmd.to_i && cmd.to_i <= PER_PAGE
     puts "\n"
-    puts "TED ID: #{video_id(@store[cmd.to_i])}"
+    puts "TED ID: #{ted_id(@store[cmd.to_i])}"
     break
   end
 end

--- a/scripts/search.rb
+++ b/scripts/search.rb
@@ -49,6 +49,8 @@ loop do
     break
   elsif 0 < cmd.to_i && cmd.to_i <= PER_PAGE
     puts "\n"
+    `echo #{PREFIX + @store[cmd.to_i]} | pbcopy`
+    puts "URL: #{PREFIX + @store[cmd.to_i]}"
     puts "TED ID: #{ted_id(@store[cmd.to_i])}"
     break
   end


### PR DESCRIPTION
ブラウザでTEDのページに行って、TED IDを検索するのが面倒なので、コマンドラインからTED IDを調べられるようにしました。

`$ bash ted list` みたいな形で実行して、選択した動画を自動でダウンロードできると良いなと思って作り始めたのですが、ted スクリプトのメイン処理をいろいろと書きなおさないといけなくなりそうなので、とりあえず検索モジュールのみ作成して、 `$ scripts/search.rb` で実行させるようにしました。

**様子**
[![Gyazo](https://bot.gyazo.com/74b58658fc597999190a8e092e99844d.gif)](https://gyazo.com/74b58658fc597999190a8e092e99844d)
